### PR TITLE
Fix assembly subworkflow and add db_cache to assembly_qc subworkflow

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -66,8 +66,6 @@ try {
     System.err.println("WARNING: Could not load nf-core/config profiles: ${params.custom_config_base}/nfcore_custom.config")
 }
 
-singularity.cacheDir = "container_cache"
-
 profiles {
     debug { process.beforeScript = 'echo $HOSTNAME' }
     conda {

--- a/workflows/arete.nf
+++ b/workflows/arete.nf
@@ -254,14 +254,22 @@ workflow ASSEMBLY {
     }
     //if (params.outgroup_genome ) { ch_outgroup_genome = file(params.outgroup_genome) } else { ch_outgroup_genome = '' }
 
+    // Setup dbcache
+    db_cache = params.db_cache ? params.db_cache : false
+
     ch_software_versions = Channel.empty()
 
     /*
      * SUBWORKFLOW: Read in samplesheet, validate and stage input files
      */
     INPUT_CHECK(ch_input)
+    if(db_cache){
+        GET_DB_CACHE(db_cache)
+        ASSEMBLE_SHORTREADS(INPUT_CHECK.out.reads, ch_reference_genome, use_reference_genome, GET_DB_CACHE.out.minikraken)
+    } else {
+        ASSEMBLE_SHORTREADS(INPUT_CHECK.out.reads, ch_reference_genome, use_reference_genome, [])
+    }
 
-    ASSEMBLE_SHORTREADS(INPUT_CHECK.out.reads, ch_reference_genome, use_reference_genome)
     ch_software_versions = ch_software_versions.mix(ASSEMBLE_SHORTREADS.out.assembly_software)
 
     // Get unique list of files containing version information


### PR DESCRIPTION
- Closes #17 

Now any of the three separate subworkflows - assembly, annotation and qualitycheck - can be run independently and use db_cache, enhancing code modularity.

Running the assembly subwf:

```
nextflow run arete/ \
    --input_sample_table samplesheet.csv \
    --db_cache ./dbcache/ \
    -entry assembly
```

Running assembly qc on the output of the assembly subwf:

```
nextflow run arete/ \
    --input_sample_table assemblies_samplesheet.csv \
    --db_cache ./dbcache/ \
    -entry assembly_qc
```

Next step will be to integrate the phylo workflow in the same manner (#13)