### PR TITLE
Refactor pipeline outputs

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -43,7 +43,7 @@ process {
 
     // read_processing
 
-    withName: '.*:FASTQC' {
+    withName: FASTQC {
         publishDir = [
             path: { "${params.outdir}/read_processing/raw_fastqc/${meta.id}" },
             mode: params.publish_dir_mode,
@@ -52,7 +52,7 @@ process {
         ]
     }
 
-    withName: '.*TRIM_FASTQC' {
+    withName: TRIM_FASTQC {
         publishDir = [
             path: { "${params.outdir}/read_processing/trim_fastqc/${meta.id}" },
             mode: params.publish_dir_mode,
@@ -61,7 +61,7 @@ process {
         ]
     }
 
-    withName: '.*FASTP' {
+    withName: FASTP {
         publishDir = [
             path: { "${params.outdir}/read_processing/fastp/${meta.id}" },
             mode: params.publish_dir_mode,
@@ -70,7 +70,7 @@ process {
         ]
     }
 
-    withName: '.*KRAKEN2_RUN' {
+    withName: KRAKEN2_RUN {
         publishDir = [
             path: { "${params.outdir}/read_processing/kraken2/${meta.id}" },
             mode: params.publish_dir_mode,
@@ -80,7 +80,7 @@ process {
 
     // assembly
 
-    withName: '.*UNICYCLER' {
+    withName: UNICYCLER {
         publishDir = [
             path: { "${params.outdir}/assembly/unicycler/${meta.id}" },
             mode: params.publish_dir_mode,
@@ -88,7 +88,7 @@ process {
         ]
     }
 
-    withName: '.*QUAST' {
+    withName: QUAST {
         publishDir = [
             path: { "${params.outdir}/assembly/quast/${meta.id}" },
             mode: params.publish_dir_mode,
@@ -96,7 +96,7 @@ process {
         ]
     }
 
-    withName: '.*CHECKM_LINEAGEWF' {
+    withName: CHECKM_LINEAGEWF {
         publishDir = [
             path: { "${params.outdir}/assembly/checkm/${meta.id}" },
             mode: params.publish_dir_mode,
@@ -106,7 +106,7 @@ process {
 
     // annotation
 
-    withName: '.*PROKKA' {
+    withName: PROKKA {
         publishDir = [
             path: { "${params.outdir}/annotation/prokka/${meta.id}" },
             mode: params.publish_dir_mode,
@@ -114,7 +114,7 @@ process {
         ]
     }
 
-    withName: '.*RGI' {
+    withName: RGI {
         publishDir = [
             path: { "${params.outdir}/annotation/rgi" },
             mode: params.publish_dir_mode,
@@ -122,7 +122,7 @@ process {
         ]
     }
 
-    withName: '.*MOB_RECON' {
+    withName: MOB_RECON {
         publishDir = [
             path: { "${params.outdir}/annotation/mob_recon/${meta.id}" },
             mode: params.publish_dir_mode,
@@ -130,7 +130,15 @@ process {
         ]
     }
 
-    withName: '.*DIAMOND_BLAST_CAZY' {
+    withName: BAKTA {
+        publishDir = [
+            path: { "${params.outdir}/annotation/bakta/${meta.id}" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        ]
+    }
+
+    withName: DIAMOND_BLAST_CAZY {
         publishDir = [
             path: { "${params.outdir}/annotation/cazy/${meta.id}" },
             mode: params.publish_dir_mode,
@@ -138,7 +146,7 @@ process {
         ]
     }
 
-    withName: '.*DIAMOND_BLAST_VFDB' {
+    withName: DIAMOND_BLAST_VFDB {
         publishDir = [
             path: { "${params.outdir}/annotation/vfdb/${meta.id}" },
             mode: params.publish_dir_mode,
@@ -146,7 +154,7 @@ process {
         ]
     }
 
-    withName: '.*DIAMOND_BLAST_BACMET' {
+    withName: DIAMOND_BLAST_BACMET {
         publishDir = [
             path: { "${params.outdir}/annotation/bacmet/${meta.id}" },
             mode: params.publish_dir_mode,
@@ -154,17 +162,18 @@ process {
         ]
     }
 
-    // phylogenomics
-    withName: '.*PANAROO_RUN' {
+    //  pangenomics
+    withName: PANAROO_RUN {
         ext.args = "-a core --clean-mode strict --len_dif_percent 0.70 -c 0.7 -f 0.5"
         publishDir = [
-            path: { "${params.outdir}/phylogenomics/panaroo" },
+            path: { "${params.outdir}/pangenomics/panaroo" },
             mode: params.publish_dir_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
     }
 
-    withName: '.*IQTREE' {
+    // phylogenomics
+    withName: IQTREE {
         publishDir = [
             path: { "${params.outdir}/phylogenomics/iqtree" },
             mode: params.publish_dir_mode,
@@ -172,7 +181,7 @@ process {
         ]
     }
 
-    withName: '.*FASTTREE' {
+    withName: FASTTREE {
         publishDir = [
             path: { "${params.outdir}/phylogenomics/fasttree" },
             mode: params.publish_dir_mode,
@@ -180,7 +189,7 @@ process {
         ]
     }
 
-    withName: '.*SNPSITES' {
+    withName: SNPSITES {
         publishDir = [
             path: { "${params.outdir}/phylogenomics/snpsites" },
             mode: params.publish_dir_mode,
@@ -188,7 +197,7 @@ process {
         ]
     }
 
-    withName: '.*MULTIQC' {
+    withName: MULTIQC {
         publishDir = [
             path: { "${params.outdir}/multiqc" },
             mode: params.publish_dir_mode,
@@ -196,7 +205,7 @@ process {
         ]
     }
 
-    withName: '.*CUSTOM_DUMPSOFTWAREVERSIONS' {
+    withName: GET_SOFTWARE_VERSIONS {
         publishDir = [
             path: { "${params.outdir}/pipeline_info" },
             mode: params.publish_dir_mode,

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -90,7 +90,7 @@ process {
 
     withName: QUAST {
         publishDir = [
-            path: { "${params.outdir}/assembly/quast/${meta.id}" },
+            path: { "${params.outdir}/assembly/quast/" },
             mode: params.publish_dir_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
@@ -108,7 +108,7 @@ process {
 
     withName: PROKKA {
         publishDir = [
-            path: { "${params.outdir}/annotation/prokka/${meta.id}" },
+            path: { "${params.outdir}/annotation/prokka/" },
             mode: params.publish_dir_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
@@ -124,7 +124,7 @@ process {
 
     withName: MOB_RECON {
         publishDir = [
-            path: { "${params.outdir}/annotation/mob_recon/${meta.id}" },
+            path: { "${params.outdir}/annotation/mob_recon/" },
             mode: params.publish_dir_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -43,36 +43,36 @@ process {
 
     // read_processing
 
-    withName: FASTQC {
+    withName: '.*:FASTQC' {
         publishDir = [
-            path: "${params.outdir}/read_processing/raw_fastqc/${meta.id}",
+            path: { "${params.outdir}/read_processing/raw_fastqc/${meta.id}" },
             mode: params.publish_dir_mode,
             pattern: "*.html",
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
     }
 
-    withName: TRIM_FASTQC {
+    withName: '.*TRIM_FASTQC' {
         publishDir = [
-            path: "${params.outdir}/read_processing/trim_fastqc/${meta.id}",
+            path: { "${params.outdir}/read_processing/trim_fastqc/${meta.id}" },
             mode: params.publish_dir_mode,
             pattern: "*.html",
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
     }
 
-    withName: FASTP {
+    withName: '.*FASTP' {
         publishDir = [
-            path: "${params.outdir}/read_processing/fastp/${meta.id}",
+            path: { "${params.outdir}/read_processing/fastp/${meta.id}" },
             mode: params.publish_dir_mode,
             pattern: "*.{html,json,gz}",
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
     }
 
-    withName: KRAKEN2_RUN {
+    withName: '.*KRAKEN2_RUN' {
         publishDir = [
-            path: "${params.outdir}/read_processing/kraken2/${meta.id}",
+            path: { "${params.outdir}/read_processing/kraken2/${meta.id}" },
             mode: params.publish_dir_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
@@ -80,25 +80,25 @@ process {
 
     // assembly
 
-    withName: UNICYCLER {
+    withName: '.*UNICYCLER' {
         publishDir = [
-            path: "${params.outdir}/assembly/unicycler/${meta.id}",
+            path: { "${params.outdir}/assembly/unicycler/${meta.id}" },
             mode: params.publish_dir_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
     }
 
-    withName: QUAST {
+    withName: '.*QUAST' {
         publishDir = [
-            path: "${params.outdir}/assembly/quast/${meta.id}",
+            path: { "${params.outdir}/assembly/quast/${meta.id}" },
             mode: params.publish_dir_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
     }
 
-    withName: CHECKM_LINEAGEWF {
+    withName: '.*CHECKM_LINEAGEWF' {
         publishDir = [
-            path: "${params.outdir}/assembly/checkm/${meta.id}",
+            path: { "${params.outdir}/assembly/checkm/${meta.id}" },
             mode: params.publish_dir_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
@@ -106,89 +106,89 @@ process {
 
     // annotation
 
-    withName: PROKKA {
+    withName: '.*PROKKA' {
         publishDir = [
-            path: "${params.outdir}/annotation/prokka/${meta.id}",
+            path: { "${params.outdir}/annotation/prokka/${meta.id}" },
             mode: params.publish_dir_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
     }
 
-    withName: RGI {
+    withName: '.*RGI' {
         publishDir = [
-            path: "${params.outdir}/annotation/rgi",
+            path: { "${params.outdir}/annotation/rgi" },
             mode: params.publish_dir_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
     }
 
-    withName: MOB_RECON {
+    withName: '.*MOB_RECON' {
         publishDir = [
-            path: "${params.outdir}/annotation/mob_recon/${meta.id}",
+            path: { "${params.outdir}/annotation/mob_recon/${meta.id}" },
             mode: params.publish_dir_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
     }
 
-    withName: DIAMOND_BLAST_CAZY {
+    withName: '.*DIAMOND_BLAST_CAZY' {
         publishDir = [
-            path: "${params.outdir}/annotation/cazy/${meta.id}",
+            path: { "${params.outdir}/annotation/cazy/${meta.id}" },
             mode: params.publish_dir_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
     }
 
-    withName: DIAMOND_BLAST_VFDB {
+    withName: '.*DIAMOND_BLAST_VFDB' {
         publishDir = [
-            path: "${params.outdir}/annotation/vfdb/${meta.id}",
+            path: { "${params.outdir}/annotation/vfdb/${meta.id}" },
             mode: params.publish_dir_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
     }
 
-    withName: DIAMOND_BLAST_BACMET {
+    withName: '.*DIAMOND_BLAST_BACMET' {
         publishDir = [
-            path: "${params.outdir}/annotation/bacmet/${meta.id}",
+            path: { "${params.outdir}/annotation/bacmet/${meta.id}" },
             mode: params.publish_dir_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
     }
 
     // phylogenomics
-    withName: PANAROO_RUN {
-        ext.args = "-a core --clean-mode strict --len_dif_percent 0.70 -c 0.7 -f 0.5",
+    withName: '.*PANAROO_RUN' {
+        ext.args = "-a core --clean-mode strict --len_dif_percent 0.70 -c 0.7 -f 0.5"
         publishDir = [
-            path: "${params.outdir}/phylogenomics/panaroo",
+            path: { "${params.outdir}/phylogenomics/panaroo" },
             mode: params.publish_dir_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
     }
 
-    withName: IQTREE {
+    withName: '.*IQTREE' {
         publishDir = [
-            path: "${params.outdir}/phylogenomics/iqtree",
+            path: { "${params.outdir}/phylogenomics/iqtree" },
             mode: params.publish_dir_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
     }
 
-    withName: FASTTREE {
+    withName: '.*FASTTREE' {
         publishDir = [
-            path: "${params.outdir}/phylogenomics/fasttree",
+            path: { "${params.outdir}/phylogenomics/fasttree" },
             mode: params.publish_dir_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
     }
 
-    withName: SNPSITES {
+    withName: '.*SNPSITES' {
         publishDir = [
-            path: "${params.outdir}/phylogenomics/snpsites",
+            path: { "${params.outdir}/phylogenomics/snpsites" },
             mode: params.publish_dir_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
     }
 
-    withName: MULTIQC {
+    withName: '.*MULTIQC' {
         publishDir = [
             path: { "${params.outdir}/multiqc" },
             mode: params.publish_dir_mode,
@@ -196,7 +196,7 @@ process {
         ]
     }
 
-    withName: CUSTOM_DUMPSOFTWAREVERSIONS {
+    withName: '.*CUSTOM_DUMPSOFTWAREVERSIONS' {
         publishDir = [
             path: { "${params.outdir}/pipeline_info" },
             mode: params.publish_dir_mode,

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -31,8 +31,177 @@ params {
     }
 }
 
-process{
-    withName: PANAROO_RUN {
-        ext.args = "-a core --clean-mode strict --len_dif_percent 0.70 -c 0.7 -f 0.5"
+process {
+    //default: do not publish process results
+
+    publishDir = [
+        path: { "${params.outdir}/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" },
+        mode: params.publish_dir_mode,
+        saveAs: { filename -> filename.equals('versions.yml') ? null : filename },
+        enabled: false
+    ]
+
+    // read_processing
+
+    withName: FASTQC {
+        publishDir = [
+            path: "${params.outdir}/read_processing/raw_fastqc/${meta.id}",
+            mode: params.publish_dir_mode,
+            pattern: "*.html",
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        ]
     }
+
+    withName: TRIM_FASTQC {
+        publishDir = [
+            path: "${params.outdir}/read_processing/trim_fastqc/${meta.id}",
+            mode: params.publish_dir_mode,
+            pattern: "*.html",
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        ]
+    }
+
+    withName: FASTP {
+        publishDir = [
+            path: "${params.outdir}/read_processing/fastp/${meta.id}",
+            mode: params.publish_dir_mode,
+            pattern: "*.{html,json,gz}",
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        ]
+    }
+
+    withName: KRAKEN2_RUN {
+        publishDir = [
+            path: "${params.outdir}/read_processing/kraken2/${meta.id}",
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        ]
+    }
+
+    // assembly
+
+    withName: UNICYCLER {
+        publishDir = [
+            path: "${params.outdir}/assembly/unicycler/${meta.id}",
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        ]
+    }
+
+    withName: QUAST {
+        publishDir = [
+            path: "${params.outdir}/assembly/quast/${meta.id}",
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        ]
+    }
+
+    withName: CHECKM_LINEAGEWF {
+        publishDir = [
+            path: "${params.outdir}/assembly/checkm/${meta.id}",
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        ]
+    }
+
+    // annotation
+
+    withName: PROKKA {
+        publishDir = [
+            path: "${params.outdir}/annotation/prokka/${meta.id}",
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        ]
+    }
+
+    withName: RGI {
+        publishDir = [
+            path: "${params.outdir}/annotation/rgi",
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        ]
+    }
+
+    withName: MOB_RECON {
+        publishDir = [
+            path: "${params.outdir}/annotation/mob_recon/${meta.id}",
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        ]
+    }
+
+    withName: DIAMOND_BLAST_CAZY {
+        publishDir = [
+            path: "${params.outdir}/annotation/cazy/${meta.id}",
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        ]
+    }
+
+    withName: DIAMOND_BLAST_VFDB {
+        publishDir = [
+            path: "${params.outdir}/annotation/vfdb/${meta.id}",
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        ]
+    }
+
+    withName: DIAMOND_BLAST_BACMET {
+        publishDir = [
+            path: "${params.outdir}/annotation/bacmet/${meta.id}",
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        ]
+    }
+
+    // phylogenomics
+    withName: PANAROO_RUN {
+        ext.args = "-a core --clean-mode strict --len_dif_percent 0.70 -c 0.7 -f 0.5",
+        publishDir = [
+            path: "${params.outdir}/phylogenomics/panaroo",
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        ]
+    }
+
+    withName: IQTREE {
+        publishDir = [
+            path: "${params.outdir}/phylogenomics/iqtree",
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        ]
+    }
+
+    withName: FASTTREE {
+        publishDir = [
+            path: "${params.outdir}/phylogenomics/fasttree",
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        ]
+    }
+
+    withName: SNPSITES {
+        publishDir = [
+            path: "${params.outdir}/phylogenomics/snpsites",
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        ]
+    }
+
+    withName: MULTIQC {
+        publishDir = [
+            path: { "${params.outdir}/multiqc" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        ]
+    }
+
+    withName: CUSTOM_DUMPSOFTWAREVERSIONS {
+        publishDir = [
+            path: { "${params.outdir}/pipeline_info" },
+            mode: params.publish_dir_mode,
+            pattern: '*_versions.yml'
+        ]
+    }
+
 }


### PR DESCRIPTION
- All publishDir directives now present under conf/modules.config as per nf-core guidelines.
- Tool outputs now under 5 different categories - read_processing, assembly, annotation, pangenomics and phylogenomics.
- For example:
```
└── read_processing
    ├── fastp
    │   ├── SRR14022735_T1
    │   ├── SRR14022737_T1
    │   ├── SRR14022754_T1
    │   └── SRR14022764_T1
    ├── raw_fastqc
    │   ├── SRR14022735_T1
    │   ├── SRR14022737_T1
    │   ├── SRR14022754_T1
    │   └── SRR14022764_T1
    └── trim_fastqc
        ├── SRR14022735_T1
        ├── SRR14022737_T1
        ├── SRR14022754_T1
        └── SRR14022764_T1
    ...

```

- Closes #14 