### PR TITLE
feat: Add option to skip kraken2 classification

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -26,6 +26,9 @@ params {
     reference_genome           = null
     outgroup_genome            = null
 
+    // Kraken2
+    skip_kraken                = false
+
     // MultiQC options
     multiqc_config             = null
     multiqc_title              = null

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -68,6 +68,20 @@
                 }
             }
         },
+        "kraken2": {
+            "title": "Kraken2",
+            "type": "object",
+            "description": "Options for the Kraken2 taxonomic classification",
+            "default": "",
+            "properties": {
+                "skip_kraken": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Don't run Kraken2 taxonomic classification"
+                }
+            },
+            "fa_icon": "fas fa-align-left"
+        },
         "annotation": {
             "title": "Annotation",
             "type": "object",
@@ -91,7 +105,6 @@
             "properties": {
                 "use_full_alignment": {
                     "type": "boolean",
-                    "default": false,
                     "description": "Use full alignment"
                 },
                 "use_fasttree": {
@@ -295,6 +308,9 @@
         },
         {
             "$ref": "#/definitions/reference_genome_options"
+        },
+        {
+            "$ref": "#/definitions/kraken2"
         },
         {
             "$ref": "#/definitions/annotation"

--- a/subworkflows/local/assembly.nf
+++ b/subworkflows/local/assembly.nf
@@ -1,25 +1,9 @@
-def summary_params = NfcoreSchema.paramsSummaryMap(workflow, params)
-/*
-========================================================================================
-    CONFIG FILES
-========================================================================================
-*/
-
-ch_multiqc_config        = file("$projectDir/assets/multiqc_config.yaml", checkIfExists: true)
-ch_multiqc_custom_config = params.multiqc_config ? Channel.fromPath(params.multiqc_config) : Channel.empty()
-
-def modules = params.modules.clone()
-
-def multiqc_options   = modules['multiqc']
-multiqc_options.args += params.multiqc_title ? Utils.joinModuleArgs(["--title \"$params.multiqc_title\""]) : ''
-
 //
 // MODULE: Installed directly from nf-core/modules
 //
 
-include { FASTQC  } from '../../modules/nf-core/modules/fastqc/main'  addParams( options: modules['fastqc'] )
-include { MULTIQC } from '../../modules/nf-core/modules/multiqc/main' addParams( options: multiqc_options   )
-include { FASTQC as TRIM_FASTQC } from '../../modules/nf-core/modules/fastqc/main'  addParams( options: modules['fastqc'] )
+include { FASTQC  } from '../../modules/nf-core/modules/fastqc/main'  addParams( options: [:]  )
+include { FASTQC as TRIM_FASTQC } from '../../modules/nf-core/modules/fastqc/main'  addParams( options: [:]  )
 include { FASTP                 } from '../../modules/nf-core/modules/fastp/main'  addParams( options: [:] )
 include { UNICYCLER             } from '../../modules/nf-core/modules/unicycler/main'  addParams( options: [:] )
 include { KRAKEN2_KRAKEN2 as KRAKEN2_RUN } from '../../modules/nf-core/modules/kraken2/kraken2/main' addParams( options: [:] )
@@ -32,9 +16,6 @@ include { CHECKM_LINEAGEWF } from '../../modules/nf-core/modules/checkm/lineagew
 //
 include { GET_SOFTWARE_VERSIONS } from '../../modules/local/get_software_versions' addParams( options: [publish_files : ['tsv':'']] )
 include { KRAKEN2_DB } from '../../modules/local/get_minikraken'  addParams( options: [:] )
-
-// Usage pattern from nf-core/rnaseq: Empty dummy file for optional inputs
-ch_dummy_input = file("$projectDir/assets/dummy_file.txt", checkIfExists: true)
 
 /*
 ========================================================================================
@@ -53,6 +34,7 @@ workflow ASSEMBLE_SHORTREADS{
         krakendb_cache
 
     main:
+        ch_multiqc_files = Channel.empty()
     /////////////////// Read Processing /////////////////////////////
         /*
         * MODULE: Run FastQC
@@ -76,18 +58,20 @@ workflow ASSEMBLE_SHORTREADS{
         ///*
         // * MODULE: Run Kraken2
         // */
-        if (krakendb_cache){
-            krakendb_cache.set { ch_kraken_db }
+        if (!params.skip_kraken) {
+            if (krakendb_cache){
+                krakendb_cache.set { ch_kraken_db }
+            }
+            else {
+                KRAKEN2_DB()
+                KRAKEN2_DB.out.minikraken.set { ch_kraken_db }
+            }
+
+
+            KRAKEN2_RUN(FASTP.out.reads, ch_kraken_db)
+            ch_software_versions = ch_software_versions.mix(KRAKEN2_RUN.out.versions.first().ifEmpty(null))
+            ch_multiqc_files = ch_multiqc_files.mix(KRAKEN2_RUN.out.txt.collect{it[1]}.ifEmpty([]))
         }
-        else {
-            KRAKEN2_DB()
-            KRAKEN2_DB.out.minikraken.set { ch_kraken_db }
-        }
-
-
-        KRAKEN2_RUN(FASTP.out.reads, ch_kraken_db)
-        ch_software_versions = ch_software_versions.mix(KRAKEN2_RUN.out.versions.first().ifEmpty(null))
-
         /////////////////// ASSEMBLE /////////////////////////////
         /*
         * MODULE: Assembly
@@ -112,10 +96,8 @@ workflow ASSEMBLE_SHORTREADS{
         QUAST(ch_to_quast, ch_reference_genome, [], use_reference_genome, false)
         ch_software_versions = ch_software_versions.mix(QUAST.out.versions.first().ifEmpty(null))
 
-        ch_multiqc_files = Channel.empty()
         ch_multiqc_files = ch_multiqc_files.mix(FASTQC.out.zip.collect{it[1]}.ifEmpty([]))
         ch_multiqc_files = ch_multiqc_files.mix(TRIM_FASTQC.out.zip.collect{it[1]}.ifEmpty([]))
-        ch_multiqc_files = ch_multiqc_files.mix(KRAKEN2_RUN.out.txt.collect{it[1]}.ifEmpty([]))
         ch_multiqc_files = ch_multiqc_files.mix(QUAST.out.tsv.collect())
 
     emit:


### PR DESCRIPTION
- Adds the --skip_kraken option to the workflow
  - This allows the workflow to skip kraken2 executions in both the assembly and assembly_qc subworkflows.
- Also removes unused boilerplate in the assembly subwf