### PR TITLE
feat: Add initialization script to the workflow

### DIFF
--- a/lib/WorkflowArete.groovy
+++ b/lib/WorkflowArete.groovy
@@ -5,20 +5,74 @@
 class WorkflowArete {
 
     //
-    // Check and validate parameters
+    // Citation string for pipeline
     //
+    public static String citation(workflow) {
+        return "If you use ${workflow.manifest.name} for your analysis please cite:\n\n" +
+            // TODO nf-core: Add Zenodo DOI for pipeline after first release
+            //"* The pipeline\n" +
+            //"  https://doi.org/10.5281/zenodo.XXXXXXX\n\n" +
+            "* The nf-core framework\n" +
+            "  https://doi.org/10.1038/s41587-020-0439-x\n\n" +
+            "* Software dependencies\n" +
+            "  https://github.com/${workflow.manifest.name}/blob/master/CITATIONS.md"
+    }
 
-    /*
-    e.g force a param to exist
-    public static void initialise(params, log) {
-        genomeExistsError(params, log)
+    //
+    // Print help to screen if required
+    //
+    public static String help(workflow, params, log) {
+        def command = "nextflow run ${workflow.manifest.name} --input_sample_table samplesheet.csv --outdir arete_results -profile docker"
+        def help_string = ''
+        help_string += NfcoreSchema.paramsHelp(workflow, params, command)
+        help_string += '\n' + citation(workflow) + '\n'
+        help_string += NfcoreTemplate.dashedLine(params.monochrome_logs)
+        return help_string
+    }
 
-        if (!params.fasta) {
-            log.error "Genome fasta file not specified with e.g. '--fasta genome.fa' or via a detectable config file."
+    //
+    // Print parameter summary log to screen
+    //
+    public static String paramsSummaryLog(workflow, params, log) {
+        def summary_log = ''
+        summary_log += NfcoreSchema.paramsSummaryLog(workflow, params)
+        summary_log += NfcoreTemplate.dashedLine(params.monochrome_logs)
+        return summary_log
+    }
+
+    //
+    // Validate parameters and print summary to screen
+    //
+    public static void initialise(workflow, params, log) {
+        // Print help to screen if required
+        if (params.help) {
+            log.info help(workflow, params, log)
+            System.exit(0)
+        }
+
+        // Validate workflow parameters via the JSON schema
+        if (params.validate_params) {
+            NfcoreSchema.validateParameters(workflow, params, log)
+        }
+
+        // Print parameter summary log to screen
+        log.info paramsSummaryLog(workflow, params, log)
+
+        // Check that conda channels are set-up correctly
+        if (params.enable_conda) {
+            Utils.checkCondaChannels(log)
+        }
+
+        // Check the hostnames against configured profiles
+        NfcoreTemplate.hostName(workflow, params, log)
+
+        // Check input has been provided
+        if (!params.input_sample_table) {
+            log.error "Please provide an input samplesheet to the pipeline e.g. '--input_sample_table samplesheet.csv'"
             System.exit(1)
         }
     }
-    */
+
     //
     // Get workflow summary for MultiQC
     //

--- a/main.nf
+++ b/main.nf
@@ -23,7 +23,7 @@ nextflow.enable.dsl = 2
 ========================================================================================
 */
 // TODO new function to validate our params
-//WorkflowMain.initialise(workflow, params, log)
+WorkflowArete.initialise(workflow, params, log)
 
 /*
 ========================================================================================

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -10,9 +10,7 @@
             "type": "object",
             "fa_icon": "fas fa-terminal",
             "description": "Define where the pipeline should find input data and save output data.",
-            "required": [
-                "input_sample_table"
-            ],
+            "required": ["input_sample_table"],
             "properties": {
                 "input_sample_table": {
                     "type": "string",
@@ -34,7 +32,7 @@
                     "type": "string",
                     "default": "None",
                     "fa_icon": "fas fa-database",
-                    "help_text": "Directory where the databases are located"
+                    "description": "Directory where the databases are located"
                 },
                 "email": {
                     "type": "string",
@@ -76,7 +74,6 @@
             "properties": {
                 "skip_kraken": {
                     "type": "boolean",
-                    "default": false,
                     "description": "Don't run Kraken2 taxonomic classification"
                 }
             },
@@ -92,7 +89,7 @@
                 "use_bakta": {
                     "type": "string",
                     "default": "None",
-                    "help_text": "Location to the bakta database"
+                    "description": "Location to the bakta database"
                 }
             }
         },
@@ -105,7 +102,8 @@
             "properties": {
                 "use_full_alignment": {
                     "type": "boolean",
-                    "description": "Use full alignment"
+                    "description": "Use full alignment",
+                    "help_text": ""
                 },
                 "use_fasttree": {
                     "type": "boolean",
@@ -221,14 +219,7 @@
                     "description": "Method used to save pipeline results to output directory.",
                     "help_text": "The Nextflow `publishDir` option specifies which intermediate files should be saved to the output directory. This option tells the pipeline what method should be used to move these files. See [Nextflow docs](https://www.nextflow.io/docs/latest/process.html#publishdir) for details.",
                     "fa_icon": "fas fa-copy",
-                    "enum": [
-                        "symlink",
-                        "rellink",
-                        "link",
-                        "copy",
-                        "copyNoFollow",
-                        "move"
-                    ],
+                    "enum": ["symlink", "rellink", "link", "copy", "copyNoFollow", "move"],
                     "hidden": true
                 },
                 "email_on_fail": {
@@ -298,6 +289,12 @@
                     "hidden": true,
                     "fa_icon": "fas fa-toolbox",
                     "help_text": "This may be useful for example if you are unable to directly pull Singularity containers to run the pipeline due to http/https proxy issues."
+                },
+                "multiqc_logo": {
+                    "type": "string",
+                    "default": null,
+                    "fa_icon": "fas fa-image",
+                    "hidden": true
                 }
             }
         }

--- a/workflows/arete.nf
+++ b/workflows/arete.nf
@@ -8,16 +8,15 @@
 def summary_params = NfcoreSchema.paramsSummaryMap(workflow, params)
 
 // Validate input parameters
-// TODO redo this
-//WorkflowArete.initialise(params, log)
+WorkflowArete.initialise(params, log)
 
-// TODO nf-core: Add all file path parameters for the pipeline to the list below
+// TODO nf-core: Add all file path parameters for the pipeline to the lis below
 // Check input path parameters to see if they exist
 def checkPathParamList = [ params.input_sample_table, params.multiqc_config, params.reference_genome ]
 for (param in checkPathParamList) { if (param) { file(param, checkIfExists: true) } }
 
 // Check mandatory parameters
-//if (params.input) { ch_input = file(params.input) } else { exit 1, 'Input samplesheet not specified!' }
+if (params.input_sample_table) { ch_input = file(params.input_sample_table) } else { exit 1, 'Input samplesheet not specified!' }
 
 /*
 ========================================================================================

--- a/workflows/arete.nf
+++ b/workflows/arete.nf
@@ -7,9 +7,6 @@
 
 def summary_params = NfcoreSchema.paramsSummaryMap(workflow, params)
 
-// Validate input parameters
-WorkflowArete.initialise(params, log)
-
 // TODO nf-core: Add all file path parameters for the pipeline to the lis below
 // Check input path parameters to see if they exist
 def checkPathParamList = [ params.input_sample_table, params.multiqc_config, params.reference_genome ]


### PR DESCRIPTION
Adds a simple initialization script showing params, e.g.:
```
Core Nextflow options
  revision                  : fix_initialization
  runName                   : silly_davinci
  containerEngine           : singularity
  launchDir                 : /lustre06/project/6070434/jvfe
  workDir                   : /lustre06/project/6070434/jvfe/work
  projectDir                : /home/jvfe/.nextflow/assets/beiko-lab/ARETE
  userName                  : jvfe
  profile                   : test,singularity,narval
  configFiles               : /home/jvfe/.nextflow/config, /home/jvfe/.nextflow/assets/beiko-lab/ARETE/nextflow.config

....
```

As a side-effect, also makes `--help` functional:

```
N E X T F L O W  ~  version 22.10.6
Launching `https://github.com/beiko-lab/ARETE` [cheesy_feynman] DSL2 - revision: e83d0d200c [fix_initialization]
Typical pipeline command:

  nextflow run beiko-lab/ARETE --input_sample_table samplesheet.csv --outdir arete_results -profile docker

Input/output options
  --input_sample_table                [string]  Path to comma-separated file containing information about the samples in the experiment.
  --outdir                            [string]  Path to the output directory where the results will be saved. [default: ./results]
  --db_cache                          [string]  Directory where the databases are located [default: None]
  --email                             [string]  Email address for completion summary.
  --multiqc_title                     [string]  MultiQC report title. Printed as page header, used for filename if not otherwise specified.

Reference genome options
  --reference_genome                  [string]  Path to FASTA reference genome file.
  --outgroup_genome                   [string]  Path to FASTA genome file to use as outgroup for tree.

Kraken2
  --skip_kraken                       [boolean] Don't run Kraken2 taxonomic classification

Annotation
  --use_bakta                         [string]  Location to the bakta database [default: None]

Phylogenomics
  --use_full_alignment                [boolean] Use full alignment
  --use_fasttree                      [boolean] Use FastTree

!! Hiding 23 params, use --show_hidden_params to show them !!
------------------------------------------------------
If you use beiko-lab/ARETE for your analysis please cite:

* The nf-core framework
  https://doi.org/10.1038/s41587-020-0439-x

* Software dependencies
  https://github.com/beiko-lab/ARETE/blob/master/CITATIONS.md
------------------------------------------------------

```