### PR TITLE
feat: Add useful VFDB IDs to annotation report

### DIFF
--- a/bin/create_report.py
+++ b/bin/create_report.py
@@ -2,8 +2,10 @@
 
 import os
 import sys
+import gzip
 import argparse
-from pandas import read_table, merge
+from Bio import SeqIO
+from pandas import read_table, merge, DataFrame, isna, NA
 from functools import reduce
 
 
@@ -27,6 +29,9 @@ def parse_args(args=None):
     )
     parser.add_argument("-r", "--rgi_out", dest="RGI", help="RGI output.")
     parser.add_argument(
+        "-r", "--vfdb_fasta", dest="VFDB_FASTA", help="VFDB reference FASTA."
+    )
+    parser.add_argument(
         "-m",
         "--mobsuite_out",
         dest="MOBSUITE",
@@ -40,21 +45,61 @@ def parse_args(args=None):
 def summarize_alignment(path, db_name):
     df = read_table(path)
 
-    summary = df[["genome_id", "qseqid", "sseqid", "pident"]]
+    summary = df.copy()[["genome_id", "qseqid", "sseqid", "pident", "qcover"]]
+
+    summary["qcover"] = summary["qcover"].where(summary["qcover"] <= 1.0, 1.0)
+    summary["qcover"] = round(summary["qcover"], 2) * 100
 
     summary = summary.rename(
-        columns={"qseqid": "orf", "sseqid": db_name, "pident": f"{db_name}_identity"}
+        columns={
+            "qseqid": "orf",
+            "sseqid": db_name,
+            "pident": f"{db_name}_identity",
+            "qcover": f"{db_name}_qcover",
+        }
     )
 
     return summary
 
 
-def create_report(ann, diamond_outs, rgi, mobsuite):
+def parse_vfdb_fasta(vfdb_fasta):
+    with gzip.open(vfdb_fasta, "rt") as handle:
+        record_dict = SeqIO.to_dict(SeqIO.parse(handle, "fasta"))
+
+    vfdb_df = DataFrame.from_dict(
+        {k: v.description for (k, v) in record_dict.items()},
+        orient="index",
+        columns=["vfdb_desc"],
+    )
+
+    return vfdb_df
+
+
+def create_vfdb_report(df, vfdb_df):
+    w_vfdb = df.copy().merge(vfdb_df, left_on="vfdb", right_index=True, how="left")
+
+    w_vfdb[["vfdb_short_id", "vfdb1", "vfdb2"]] = (
+        w_vfdb["vfdb_desc"].str.extractall("\(([^()]\w+\/?\w+)\)").unstack()
+    )
+
+    w_vfdb["vfdb"] = w_vfdb[["vfdb", "vfdb1", "vfdb2"]].apply(
+        lambda row: "/".join(row.values.astype(str)) if not isna(row.values[0]) else NA,
+        axis=1,
+    )
+    w_vfdb = w_vfdb.drop(columns=["vfdb_desc", "vfdb1", "vfdb2"])
+
+    return w_vfdb
+
+
+def create_report(ann, diamond_outs, rgi, vfdb_fasta, mobsuite):
     # Summarize DIAMOND outs
     diamond_sums = [
         summarize_alignment(out, os.path.basename(out).strip(".txt").lower())
         for out in diamond_outs
     ]
+
+    # Get VFDB df
+    vfdb_df = parse_vfdb_fasta(vfdb_fasta)
 
     # RGI output
     rgi_df = read_table(rgi)
@@ -90,6 +135,8 @@ def create_report(ann, diamond_outs, rgi, mobsuite):
 
     orf_ann = ann_sum.merge(orf_based_merged, on=["genome_id", "orf"], how="inner")
 
+    w_vfdb = create_vfdb_report(orf_ann, vfdb_df)
+
     if mobsuite is not None and ann_tool == "bakta":
         # MobRecon output
         mobrecon = read_table(mobsuite)
@@ -107,7 +154,7 @@ def create_report(ann, diamond_outs, rgi, mobsuite):
         )
 
         merged_full = mobsuite_ann.merge(
-            orf_ann, on=["genome_id", "orf", "contig_id", "Start", "Stop"], how="outer"
+            w_vfdb, on=["genome_id", "orf", "contig_id", "Start", "Stop"], how="outer"
         )
 
         merged_full.to_csv(
@@ -115,12 +162,12 @@ def create_report(ann, diamond_outs, rgi, mobsuite):
         )
 
     else:
-        orf_ann.to_csv(path_or_buf="annotation_report.tsv.gz", sep="\t", index=False)
+        w_vfdb.to_csv(path_or_buf="annotation_report.tsv.gz", sep="\t", index=False)
 
 
 def main(args=None):
     args = parse_args(args)
-    create_report(args.ANN, args.DIAMOND_OUTS, args.RGI, args.MOBSUITE)
+    create_report(args.ANN, args.DIAMOND_OUTS, args.RGI, args.VFDB_FASTA, args.MOBSUITE)
 
 
 if __name__ == "__main__":

--- a/bin/create_report.py
+++ b/bin/create_report.py
@@ -107,7 +107,11 @@ def create_report(ann, diamond_outs, rgi, vfdb_fasta, mobsuite):
 
     # RGI output
     rgi_df = read_table(rgi)
-    rgi_sum = rgi_df[rgi_df["Best_Identities"] > 80]
+    rgi_df.columns = rgi_df.columns.str.replace(" ", "_")
+    rgi_sum = rgi_df[
+        (rgi_df["Best_Identities"] > 80)
+        & (rgi_df["Percentage_Length_of_Reference_Sequence"] > 80)
+    ]
     rgi_sum = rgi_sum[["Contig", "Best_Hit_ARO", "Cut_Off", "genome_id"]].rename(
         columns={"Contig": "orf", "Best_Hit_ARO": "AMR", "Cut_Off": "rgi_cutoff"}
     )

--- a/bin/create_report.py
+++ b/bin/create_report.py
@@ -76,19 +76,23 @@ def parse_vfdb_fasta(vfdb_fasta):
 
 
 def create_vfdb_report(df, vfdb_df):
-    w_vfdb = df.copy().merge(vfdb_df, left_on="vfdb", right_index=True, how="left")
+    if not df["vfdb"].isna().all():
+        w_vfdb = df.copy().merge(vfdb_df, left_on="vfdb", right_index=True, how="left")
 
-    w_vfdb[["vfdb_short_id", "vfdb1", "vfdb2"]] = (
-        w_vfdb["vfdb_desc"].str.extractall("\(([^()]\w+\/?\w+)\)").unstack()
-    )
+        w_vfdb[["vfdb_short_id", "vfdb1", "vfdb2"]] = (
+            w_vfdb["vfdb_desc"].str.extractall("\(([^()]\w+\/?\w+)\)").unstack()
+        )
 
-    w_vfdb["vfdb"] = w_vfdb[["vfdb", "vfdb1", "vfdb2"]].apply(
-        lambda row: "/".join(row.values.astype(str)) if not isna(row.values[0]) else NA,
-        axis=1,
-    )
-    w_vfdb = w_vfdb.drop(columns=["vfdb_desc", "vfdb1", "vfdb2"])
+        w_vfdb["vfdb"] = w_vfdb[["vfdb", "vfdb1", "vfdb2"]].apply(
+            lambda row: "/".join(row.values.astype(str))
+            if not isna(row.values[0])
+            else NA,
+            axis=1,
+        )
+        w_vfdb = w_vfdb.drop(columns=["vfdb_desc", "vfdb1", "vfdb2"])
 
-    return w_vfdb
+        return w_vfdb
+    return df
 
 
 def create_report(ann, diamond_outs, rgi, vfdb_fasta, mobsuite):

--- a/bin/create_report.py
+++ b/bin/create_report.py
@@ -29,7 +29,7 @@ def parse_args(args=None):
     )
     parser.add_argument("-r", "--rgi_out", dest="RGI", help="RGI output.")
     parser.add_argument(
-        "-r", "--vfdb_fasta", dest="VFDB_FASTA", help="VFDB reference FASTA."
+        "-f", "--vfdb_fasta", dest="VFDB_FASTA", help="VFDB reference FASTA."
     )
     parser.add_argument(
         "-m",

--- a/modules/local/create_report.nf
+++ b/modules/local/create_report.nf
@@ -3,15 +3,16 @@ process CREATE_REPORT {
 
     conda (params.enable_conda ? "conda-forge::pandas=1.4.3" : null)
     if (workflow.containerEngine == 'singularity' && !params.singularity_pull_docker_container) {
-        container "https://depot.galaxyproject.org/singularity/pandas:1.4.3"
+        container "https://depot.galaxyproject.org/singularity/mulled-v2-1e9d4f78feac0eb2c8d8246367973b3f6358defc:ebca4356a18677aaa2c50f396a408343200e514b-0"
     } else {
-        container "quay.io/biocontainers/pandas:1.4.3"
+        container "quay.io/biocontainers/mulled-v2-1e9d4f78feac0eb2c8d8246367973b3f6358defc:ebca4356a18677aaa2c50f396a408343200e514b-0"
     }
 
     input:
     path annotation
     path diamond_results
     path rgi_output
+    path vfdb_fasta
     path mobsuite_output
 
     output:
@@ -23,6 +24,7 @@ process CREATE_REPORT {
         --annotation_out $annotation \\
         --diamond_outs $diamond_results \\
         --rgi_out $rgi_output \\
+        --vfdb_fasta $vfdb_fasta \\
         --mobsuite_out $mobsuite_output
     """
 

--- a/subworkflows/local/annotation.nf
+++ b/subworkflows/local/annotation.nf
@@ -304,6 +304,7 @@ workflow ANNOTATE_ASSEMBLIES {
                 CONCAT_BAKTA.out.txt,
                 ch_diamond_outs.collect(),
                 CONCAT_RGI.out.txt,
+                ch_vfdb,
                 CONCAT_MOBSUITE.out.txt
             )
         } else {
@@ -311,6 +312,7 @@ workflow ANNOTATE_ASSEMBLIES {
                 CONCAT_PROKKA.out.txt,
                 ch_diamond_outs.collect(),
                 CONCAT_RGI.out.txt,
+                ch_vfdb,
                 []
             )
         }


### PR DESCRIPTION
- Parses VFDB reference to get the useful seq records, merging them into
  the final dataframe.
- Also now adds qcover to every diamond-based annotation output
- Changes image for create_report to be able to use both pandas and biopython

- Closes #104
