### PR TITLE
refactor: Use 'samplesheet' for alignment concat

### DIFF
--- a/bin/concatenate_aln.py
+++ b/bin/concatenate_aln.py
@@ -13,7 +13,8 @@ alignments = defaultdict()
 print("Reading alignments...", file=sys.stderr)
 
 for filepath in sys.stdin:
-    alnName = Path(filepath.strip()).stem
+    filepath = filepath.strip()
+    alnName = Path(filepath).stem
     if os.stat(filepath).st_size != 0:
         curSeq = ""
         with open(filepath, "r") as file:

--- a/bin/concatenate_aln.py
+++ b/bin/concatenate_aln.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 import os
 import sys
+from pathlib import Path
 from collections import defaultdict
 
 sequences = defaultdict()
@@ -11,9 +12,8 @@ alignments = defaultdict()
 
 print("Reading alignments...", file=sys.stderr)
 
-for alnName in sys.stdin:
-    alnName = alnName.strip()
-    filepath = alnName + ".aln"
+for filepath in sys.stdin:
+    alnName = Path(filepath.strip()).stem
     if os.stat(filepath).st_size != 0:
         curSeq = ""
         with open(filepath, "r") as file:

--- a/modules/local/concat_alignment.nf
+++ b/modules/local/concat_alignment.nf
@@ -9,7 +9,7 @@ process CONCAT_ALIGNMENT {
     }
 
     input:
-    path alignments
+    path alignment_sheet
     path exact_core
     path soft_core
 
@@ -19,7 +19,8 @@ process CONCAT_ALIGNMENT {
     script:
     """
     cat $exact_core $soft_core | sort | uniq > full_core.txt
-    cat full_core.txt | concatenate_aln.py > core_gene_alignment.aln
+    grep -f full_core.txt $alignment_sheet > file_list.txt
+    cat file_list.txt | concatenate_aln.py > core_gene_alignment.aln
     """
 
     stub:

--- a/subworkflows/local/phylo.nf
+++ b/subworkflows/local/phylo.nf
@@ -46,8 +46,15 @@ workflow PHYLOGENOMICS{
 
             PPANGGOLIN_MSA.out.alignments.set{ ch_all_alignments }
 
+            ch_all_alignments
+                .collect()
+                .flatten()
+                .map{it -> it.toString() }
+                .collectFile(name: 'aln_paths.txt', newLine: true)
+                .set{ alignment_sheet }
+
             CONCAT_ALIGNMENT (
-                ch_all_alignments,
+                alignment_sheet,
                 PPANGGOLIN_WORKFLOW.out.exact_core,
                 PPANGGOLIN_WORKFLOW.out.soft_core
             )


### PR DESCRIPTION
- Should fix bug when .command.run is too big for SLURM
