### PR TITLE
feat: Add light profile to config

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,23 @@ Parameters used:
 - `-entry annotation` - Run annotation subworkflow and further steps (See [usage](https://beiko-lab.github.io/arete/usage/)).
 - `-profile large,docker` - Run tools in docker containers. For `-profile large`, check our [resource requirements documentation](https://beiko-lab.github.io/arete/resource_profiles/).
 
+### Annotation on a tiny dataset (4-12 genomes) in a personal computer
+
+While ARETE is primarily designed to run in HPC clusters, we have implemented a simple, bare-bones version that is able to run on most modern computers and laptops, with at most 6 CPU cores and a minimum of 8GB of memory.
+
+Keep in mind this will make it impossible to run most tools included in ARETE, but it should still provide a useful testing ground.
+
+```bash
+nextflow run beiko-lab/ARETE \
+ --input_sample_table samplesheet.csv \
+ --poppunk_model bgmm \
+ -entry annotation \
+ -profile light,docker
+```
+
+- Note the addition of the `light` profile, this is the configuration for running on personal computers.
+- Check out how to [assign resource requests](https://beiko-lab.github.io/arete/usage/#custom-resource-requests) for even more customization.
+
 ## Credits <a name="credits"></a>
 
 The ARETE software was originally written and developed by [Finlay Maguire](https://github.com/fmaguire) and [Alex Manuele](https://github.com/alexmanuele), and is currently developed by [João Cavalcante](https://github.com/jvfe).

--- a/conf/light.config
+++ b/conf/light.config
@@ -1,0 +1,40 @@
+params {
+    config_profile_name        = 'Light profile'
+    config_profile_description = 'Profile for personal computers'
+
+
+    db_cache = false
+    use_ppanggolin = true
+    use_fasttree = true
+    enable_subsetting = true
+    use_prokka = true
+    skip_kraken = true
+    skip_poppunk = true
+    annotation_tools = 'mobsuite,rgi,vfdb,report'
+}
+
+process {
+    withLabel:process_single {
+        cpus   =  1
+        memory = 6.GB
+        time   = 4.h
+    }
+    withLabel:process_low {
+        cpus   =  6
+        memory = 6.GB
+        time   = 4.h
+    }
+    withLabel:process_medium {
+        cpus   =  6
+        memory = 6.GB
+        time   = 4.h
+    }
+    withLabel:process_high {
+        cpus   =  6
+        memory = 8.GB
+        time   = 4.h
+    }
+    withLabel:process_high_memory {
+        memory = 8.GB
+    }
+}

--- a/docs/resource_profiles.md
+++ b/docs/resource_profiles.md
@@ -17,3 +17,6 @@ The sizes are:
 - For the `large` profile, we expect datasets with >1000 samples.
   It also increases default resource requirements for some processes and uses PPanGGoLin.
   Additionally, **it enables [PopPUNK subsampling](subsampling.md), with default parameters**.
+
+- For the `light` profile, we expect datasets with at most 12 samples.
+  This is a profile primarily designed to run on personal computers and it disables most ARETE processes.

--- a/nextflow.config
+++ b/nextflow.config
@@ -184,6 +184,7 @@ profiles {
     }
     test      { includeConfig 'conf/test.config'      }
     test_full { includeConfig 'conf/test_full.config' }
+    light     { includeConfig 'conf/light.config' }
     medium    { includeConfig 'conf/medium.config' }
     large     { includeConfig 'conf/large.config' }
 }


### PR DESCRIPTION
- Adds a new profile designed to perform runs in personal computers/laptops
- Adds corresponding documentation

## Performance results
Here are some performance results for running the test_full dataset in this config:
- CPU usage:
![](https://github.com/beiko-lab/arete/assets/43506501/74cd9707-35ef-471d-b193-b4edd26f7f1b)
- Memory usage:
![](https://github.com/beiko-lab/arete/assets/43506501/714af913-b123-4ac0-a9af-cd52a633fe86)

